### PR TITLE
Travis publica a gh_pages solo cambios en master

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,4 +26,4 @@ script:
 
 after_success:
   - chmod 755 ./.push_gh_pages.sh
-  - ./.push_gh_pages.sh
+  - test $TRAVIS_PULL_REQUEST == "false" && test $TRAVIS_BRANCH == "master" && ./.push_gh_pages.sh


### PR DESCRIPTION
Arreglé el archivo de travis para que publique a gh_pages solo cambios en master. Closes #5.
Gracias a https://stackoverflow.com/questions/20665007/how-to-publish-only-when-on-master-branch-under-travis-and-sbt-0-13
